### PR TITLE
Improve the editing experience on iOS

### DIFF
--- a/Sources/HighlightedTextEditor/HighlightedTextEditor.iOS.swift
+++ b/Sources/HighlightedTextEditor/HighlightedTextEditor.iOS.swift
@@ -45,6 +45,13 @@ public struct HighlightedTextEditor: UIViewRepresentable, HighlightingTextEditor
     public func updateUIView(_ uiView: UITextView, context: Context) {
         uiView.isScrollEnabled = false
         
+        let cursor = uiView.selectedRange
+        defer {
+            if uiView.attributedText.length <= cursor.upperBound {
+                uiView.selectedRange = cursor
+            }
+        }
+        
         let highlightedText = HighlightedTextEditor.getHighlightedText(text: text, highlightRules: highlightRules)
 
         uiView.attributedText = highlightedText

--- a/Sources/HighlightedTextEditor/HighlightedTextEditor.iOS.swift
+++ b/Sources/HighlightedTextEditor/HighlightedTextEditor.iOS.swift
@@ -46,23 +46,36 @@ public struct HighlightedTextEditor: UIViewRepresentable, HighlightingTextEditor
         uiView.isScrollEnabled = false
         
         let cursor = uiView.selectedRange
-        defer {
-            if uiView.attributedText.length <= cursor.upperBound {
+        if cursor.upperBound <= uiView.attributedText.length {
+            context.coordinator.updating = cursor
+            // Attributedtext is updating the position the next tick
+            // Therefore, so are we
+            DispatchQueue.main.async {
                 uiView.selectedRange = cursor
+                context.coordinator.updating = nil
             }
         }
         
         let highlightedText = HighlightedTextEditor.getHighlightedText(text: text, highlightRules: highlightRules)
 
         uiView.attributedText = highlightedText
-        uiView.isScrollEnabled = true
+        DispatchQueue.main.async {
+            uiView.isScrollEnabled = true
+        }
     }
 
     public class Coordinator: NSObject, UITextViewDelegate {
         var parent: HighlightedTextEditor
+        var updating: NSRange?
 
         init(_ markdownEditorView: HighlightedTextEditor) {
             self.parent = markdownEditorView
+        }
+        
+        public func textViewDidChangeSelection(_ textView: UITextView) {
+            if let updating = updating {
+                textView.selectedRange = updating
+            }
         }
         
         public func textViewDidChange(_ textView: UITextView) {


### PR DESCRIPTION
Prior to this patch, changes to markup would put the cursor on the end of the view and scroll down to the end. This change fixes that.