### PR TITLE
Supports languages with two-stage autocorrect

### DIFF
--- a/Sources/HighlightedTextEditor/HighlightedTextEditor.iOS.swift
+++ b/Sources/HighlightedTextEditor/HighlightedTextEditor.iOS.swift
@@ -63,7 +63,11 @@ public struct HighlightedTextEditor: UIViewRepresentable, HighlightingTextEditor
             color: color
         )
 
-        uiView.attributedText = highlightedText
+        if let range = uiView.markedTextNSRange {
+            uiView.setAttributedMarkedText(highlightedText, selectedRange: range)
+        } else {
+            uiView.attributedText = highlightedText
+        }
         updateTextViewModifiers(uiView)
         uiView.isScrollEnabled = true
         uiView.selectedTextRange = context.coordinator.selectedTextRange

--- a/Sources/HighlightedTextEditor/System Extensions/UITextView.swift
+++ b/Sources/HighlightedTextEditor/System Extensions/UITextView.swift
@@ -1,0 +1,20 @@
+//
+//  UITextView.swift
+//  
+//
+//  Created by Kyle Nazario on 11/13/20.
+//
+
+#if os(iOS)
+import Foundation
+import UIKit
+
+extension UITextView {
+    var markedTextNSRange: NSRange? {
+        guard let markedTextRange = markedTextRange else { return nil }
+        let location = offset(from: beginningOfDocument, to: markedTextRange.start)
+        let length = offset(from: markedTextRange.start, to: markedTextRange.end)
+        return NSRange(location: location, length: length)
+    }
+}
+#endif


### PR DESCRIPTION
Some languages use two-stage autocorrect, such as the Chinese Traditional Pinyin keyboard. For the Pinyin keyboard, the user types English characters, which are autocorrected and replaced by Chinese characters. 

UITextView uses "marked" text to track these English characters that are to be replaced. This PR adds marked text tracking (and Chinese / Japanese keyboard compatibility) to the UIKit editor. 