### PR TITLE
Fixed default font for empty text

### DIFF
--- a/Sources/HighlightedTextEditor/HighlightedTextEditor.iOS.swift
+++ b/Sources/HighlightedTextEditor/HighlightedTextEditor.iOS.swift
@@ -48,6 +48,7 @@ public struct HighlightedTextEditor: UIViewRepresentable, HighlightingTextEditor
         textView.delegate = context.coordinator
         textView.isEditable = true
         textView.isScrollEnabled = true
+        textView.font = font
         updateTextViewModifiers(textView)
 
         return textView


### PR DESCRIPTION
Hi, I fixed a minor bug that appeared when the editor starts with an empty string. The set default font was not applied for the `textView` (for iOS) which caused the insertion point to be initially smaller than wanted.

The bug was reproduceble with the simple example
```
struct ContentView: View {
    @State private var text: String = ""
    
    var body: some View {
        HighlightedTextEditor(text: $text, highlightRules: [])
            .defaultFont(.systemFont(ofSize: 30))
    }
}
```
The insertion point gets bigger once you start typing. 
![screen-recording](https://user-images.githubusercontent.com/20423069/102928662-6b8cb280-4499-11eb-917d-1283156cb922.gif)
I'm not sure if this bug also exists for macOS.