### PR TITLE
Respect the current formatting for new text entry

### DIFF
--- a/Sources/HighlightedTextEditor/HighlightedTextEditor.AppKit.swift
+++ b/Sources/HighlightedTextEditor/HighlightedTextEditor.AppKit.swift
@@ -47,6 +47,13 @@ public struct HighlightedTextEditor: NSViewRepresentable, HighlightingTextEditor
     public func makeNSView(context: Context) -> ScrollableTextView {
         let textView = ScrollableTextView()
         textView.delegate = context.coordinator
+        let emptyString = ""
+        let defaultRuleEditorFont = highlightRules
+            .first { $0.pattern == NSRegularExpression.all }?
+            .formattingRules
+            .first { $0.key == .font }?
+            .calculateValue?(emptyString, Range(uncheckedBounds: (lower: emptyString.startIndex, upper: emptyString.endIndex))) as? NSFont
+        textView.textView.font = defaultRuleEditorFont ?? defaultEditorFont
         runIntrospect(textView)
 
         return textView


### PR DESCRIPTION
I've been seeing text jumping during typing after applying formatting with different font sizes. Reproducing this is a little fiddly, but seems to stem from the fact that the typing attributes don't reliably pick up the style from the underlying NSAttributedString.

This change explicitly sets the typing attributes to match the attributes at the insertion point, failing over to the default editor font if the editor is empty.
